### PR TITLE
V1.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,16 @@
-install: webami.go 
+compile: webami.go 
 	echo "Compiling webami..."
 	go build -o bin/webami webami.go 
+
+compile_linux_amd64: webami.go
+	echo "Compiling webami..."
+	env GOOS=linux GOARCH=amd64 go build -o bin/linux/ webami.go 
+
+compile_windows_amd64: webami.go 
+	echo "Compiling webami..."
+	env GOOS=windows GOARCH=amd64 go build -o bin/windows/webami.exe webami.go
+
+compile_all_systems: compile_linux_amd64 compile_windows_amd64
 
 clean: 
 	echo "Cleaning up..."

--- a/README.md
+++ b/README.md
@@ -26,12 +26,11 @@ More features will be added soon and will be documented here but to get the full
 # The TODO List...
 The current feature set is minimal and whilst it's enough to get the job done (get your public IP), it can definitely be improved. Future features on the TO DO list include:
 
-- The ability to specify additional sources to retrieve your Public IP address. This could include a self-hosted version of Ipify. 
-- A set of expoted libraries to allow re-use with other Go programs.
+- ~The ability to specify additional sources to retrieve your Public IP address. This could include a self-hosted version of Ipify.~
 - Addition of simple build and tests.
 
 # Credit where credit is due
 webami uses [Ipify](https://www.ipify.org/) to retrieve your public IP address. It is essentially a command-line wrap around the Ipify API. Ipify is a seperate, unrelated project (maintained by Randall Degges) which has it's source code in a [Github Repository](https://github.com/rdegges/ipify-api). 
 
 # License
-![license](https://img.shields.io/github/license/jonbayl/webami) webami is licensed under a [MIT](https://choosealicense.com/licenses/mit/) license.
+![license](https://img.shields.io/github/license/jonbayl/webami)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Move the resultant "webami" executable to your `PATH` for easy usage.
 There really isn't much to using webami! Once it's compiled, simply use the executable:
 `./webami`
 
+You can specify a different IP retrieval service if you wish. You can do this using the use command: `./webami use https://api.ipify.org`. You are free to use whatever IP retrieval service you like, for example your own self-hosted version of Ipify or an alternative service. However, webami expects the output of the service used to follow some simple rules:
+- The service must be accessible using either the HTTP or HTTPS protocol
+- The service must present the Content-Type: plain/text
+- The IP address must be the only thing returned in the response body.
+
 If you're interested, you can get your current version of webami using: `./webami version`. 
 
 More features will be added soon and will be documented here but to get the full webami help, use: `./webami help`.

--- a/webami.go
+++ b/webami.go
@@ -19,6 +19,7 @@ func help() {
 	fmt.Println("\nUsage: simply run the webami executable to retrieve your public IP address.")
 	fmt.Println("\nOther arguments:")
 	fmt.Println("version: prints the current version of webami.")
+	fmt.Println("use: specify the IP retrieveal service to use. Takes one argument which must be a valid URL, all other arguments are ignored. Example: webami use https://api.ipify.org")
 
 	os.Exit(0)
 }

--- a/webami.go
+++ b/webami.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"os"
+	"regexp"
 )
 
 const version string = "v1.2"
@@ -20,9 +22,18 @@ func help() {
 	os.Exit(0)
 }
 
+func validateIp(ip []byte) error {
+	reg, _ := regexp.Match("^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$", ip)
+	if reg != true {
+		return errors.New("an invalid response was returned by the queried service, it was not an IP address")
+	}
+
+	return nil
+}
+
 func getPublicIp() {
 	client := &http.Client{}
-	req, err := http.NewRequest("GET", "https://api.ipify.org", nil)
+	req, err := http.NewRequest("GET", "http://localhost:8080/ip", nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -33,6 +44,10 @@ func getPublicIp() {
 		log.Fatal(err)
 	}
 	ip, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = validateIp(ip)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/webami.go
+++ b/webami.go
@@ -8,7 +8,7 @@ import (
 	"os"
 )
 
-var version string = "v1.1"
+const version string = "v1.2"
 
 func help() {
 	fmt.Println("webami - A whoami for the internet.")

--- a/webami.go
+++ b/webami.go
@@ -21,7 +21,14 @@ func help() {
 }
 
 func getPublicIp() {
-	resp, err := http.Get("https://api.ipify.org")
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", "https://api.ipify.org", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Add("User-Agent", "webami/"+version)
+
+	resp, err := client.Do(req)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
v1.2 of webami:
- Enhanced CLI features; the ability to select an IP retrieval service using `./webami use` (see README for full details)
- Proper IP validation: you'll now be shown a simple error if the service used did not return an IP address. 
- Makefile improvements: easy compilation for Windows and Linux on amd64 architectures. 

